### PR TITLE
Added -std=c++17 to .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,8 @@
 # Address sanitizer configuration.
 # ASAN_SYMBOLIZER_PATH=/usr/local/Cellar/llvm/13.0.0_1/bin/llvm-symbolizer
 
+build --action_env=BAZEL_CXXOPTS="-std=c++17"
+
 # Address sanitizer config
 # Use with bazel run --config=asan or lsan
 build:asan --strip=never


### PR DESCRIPTION
Hi,

I noticed `hello_world_test` wouldn't build unless I added the line in `.bazelrc` to specify that c++17 has to be used.

