### PR TITLE
Fixed test build target

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ A sample test file is [tests/cpplib_test.cc](tests/cpplib_test.cc) which uses [t
 You can run the test using [`bazel`](installing-bazel):
 
 ```bash
-bazel test tests:tests
+bazel test tests:all
 ```
 
 # More info on GLOG


### PR DESCRIPTION
Hello there,

It looks like the tests:tests target is was removed, but the command to call it is still in the README.